### PR TITLE
Create uniquely-configured envs per test [squashed]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ designate-carina/
 *.pyc
 /.venv
 /.tox
+ruiner.conf

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: designate-carina ruin
 
 designate-carina:
 	git clone git@github.com:rackerlabs/designate-carina.git
-	cd designate-carina && git checkout d8f6fefa300a87d515bfa9313b8921b2555d3ca4
+	cd designate-carina && git checkout 538b0bf5f70d0279401be6a2072a32b8f2f2fba9
 
 lint:
 	tox -e flake8

--- a/ruiner/common/config.py
+++ b/ruiner/common/config.py
@@ -14,6 +14,9 @@ cfg.CONF.register_group(cfg.OptGroup('ruiner'))
 cfg.CONF.register_opts([
     cfg.IntOpt("interval", default=3),
     cfg.IntOpt("timeout", default=120),
+    cfg.IntOpt("service_startup_wait_time", default=15,
+               help="How to wait after `docker-compose up` for services to "
+                    "be ready."),
 ], group='ruiner')
 
 cfg.CONF(args=[], default_config_files=[get_location()])

--- a/ruiner/common/config.py
+++ b/ruiner/common/config.py
@@ -1,0 +1,19 @@
+import os.path
+
+from oslo_config import cfg
+
+
+def get_location(name='ruiner.conf'):
+    path = os.path.realpath(os.environ.get('RUINER_CONF', name))
+    if not os.path.exists(path):
+        raise Exception("Failed to find config file at %r" % path)
+    return path
+
+cfg.CONF.register_group(cfg.OptGroup('ruiner'))
+
+cfg.CONF.register_opts([
+    cfg.IntOpt("interval", default=3),
+    cfg.IntOpt("timeout", default=120),
+], group='ruiner')
+
+cfg.CONF(args=[], default_config_files=[get_location()])

--- a/ruiner/common/ini.py
+++ b/ruiner/common/ini.py
@@ -1,0 +1,36 @@
+from ConfigParser import ConfigParser
+from ConfigParser import NoSectionError
+from cStringIO import StringIO
+
+
+class IniFile(object):
+    """Simple utility for editing an ini file in place.
+
+    This is not thread safe. Don't write the same file from multiple threads.
+    """
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def set(self, section_name, key, value):
+        config = self._read()
+        try:
+            config.set(section_name, key, value)
+        except NoSectionError:
+            config.add_section(section_name)
+            config.set(section_name, key, value)
+        self._write(config)
+
+    def _write(self, config):
+        with open(self.filename, 'w') as f:
+            config.write(f)
+
+    def _read(self):
+        config = ConfigParser(allow_no_value=True)
+
+        # ConfigParser refuses to read an empty file
+        contents = open(self.filename, 'r').read().strip()
+        if contents:
+            config.readfp(StringIO(contents))
+
+        return config

--- a/ruiner/common/utils.py
+++ b/ruiner/common/utils.py
@@ -1,6 +1,8 @@
+import json
 import subprocess
 import random
 import string
+import os
 
 import dns
 import dns.exception
@@ -76,7 +78,11 @@ def resp_to_string(resp):
     if resp.text and len(resp.text) > 1000:
         msg += "\n{0}... <truncated>".format(resp.text[:1000])
     else:
-        msg += "\n{0}".format(resp.text)
+        try:
+            msg += "\n{0}".format(json.dumps(resp.text, indent=2))
+        except:
+            msg += "\n{0}".format(resp.text)
+
     return msg
 
 
@@ -115,10 +121,22 @@ def random_zone(name='pooey', tld='com'):
         >>> random_zone(name='pooey', tld='com')
         'pooey-mjxWsMnz.com.'
     """
-    chars = "".join([random.choice(string.letters) for _ in range(8)])
+    chars = "".join(random.choice(string.ascii_letters) for _ in range(8))
     return '{0}-{1}.{2}.'.format(name, chars, tld)
 
 
 def require_success(result):
     out, err, ret = result
     assert ret == 0
+
+
+def random_project_name():
+    chars = "".join(random.choice(string.ascii_letters) for _ in range(8))
+    return "ruin_designate_%s" % chars
+
+
+def cleanup_file(filename):
+    try:
+        os.remove(filename)
+    except OSError:
+        pass

--- a/ruiner/common/waiters.py
+++ b/ruiner/common/waiters.py
@@ -1,7 +1,7 @@
 import time
 
 
-def wait_for_status(api_call, statuses, timeout):
+def wait_for_status(api_call, statuses, interval, timeout):
     """Wait for the zone to show the status
 
     :param statuses: if the status is in this list, stop polling
@@ -16,11 +16,11 @@ def wait_for_status(api_call, statuses, timeout):
             break
         if resp.json()["status"] in statuses:
             break
-        time.sleep(1)
+        time.sleep(interval)
     return resp
 
 
-def wait_for_404(api_call, timeout):
+def wait_for_404(api_call, interval, timeout):
     """Wait for a zone to return a 404"""
 
     end = time.time() + timeout
@@ -30,5 +30,5 @@ def wait_for_404(api_call, timeout):
             break
         if end < time.time():
             break
-        time.sleep(1)
+        time.sleep(interval)
     return resp

--- a/ruiner/test/base.py
+++ b/ruiner/test/base.py
@@ -145,9 +145,9 @@ class BaseTest(unittest.TestCase):
         _, _, ret = self.docker_composer.up()
         self.assertEqual(ret, 0)
 
-        sleep_time = 15
+        sleep_time = cfg.CONF.ruiner.service_startup_wait_time
         LOG.info("waiting %s seconds for services to start up", sleep_time)
-        time.sleep(15)
+        time.sleep(sleep_time)
 
     def cleanup_environment(self):
         LOG.info("======== cleaning up env (%s) ========", self.project_name)

--- a/ruiner/test/base.py
+++ b/ruiner/test/base.py
@@ -1,4 +1,8 @@
+import time
 import unittest
+import tempfile
+import os
+import shutil
 
 import dns.exception
 
@@ -6,6 +10,7 @@ from ruiner.common import designate
 from ruiner.common import docker
 from ruiner.common import utils
 from ruiner.common import waiters
+from ruiner.common.config import cfg
 
 LOG = utils.create_logger(__name__)
 
@@ -14,50 +19,160 @@ class BaseTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        LOG.info("======== base class setup ========")
         super(BaseTest, cls).setUpClass()
-        # these are specific to designate-carina
-        compose_files = [
-            "base.yml", "envs/slappy-bind/designate.yml",
-            "envs/slappy-bind/bind.yml",
-        ]
-        cls.docker_composer = docker.DockerComposer(
-            compose_files=compose_files,
+        cls.interval = cfg.CONF.ruiner.interval
+        cls.timeout = cfg.CONF.ruiner.timeout
+
+    def setUp(self):
+        LOG.info("======== base class setup ========")
+        super(BaseTest, self).setUp()
+
+        self.carina_dir = docker.discover_designate_carina_dir()
+        self.project_name = utils.random_project_name()
+
+        self.init_tmp_dir()
+        self.init_designate_conf()
+        self.init_docker_compose_yaml()
+
+        # this can be overridden in subclasses to configure designate however
+        self.configure_designate_conf()
+        self.show_designate_conf()
+
+        self.docker_composer = docker.DockerComposer(
+            compose_files=[
+                "base.yml", self.designate_yaml, "envs/slappy-bind/bind.yml",
+            ],
+            project_name=self.project_name,
+            carina_dir=self.carina_dir,
         )
 
-        cls.api = designate.API(
-            "http://%s" % cls.docker_composer.get_host("api", 9001)
+        self.deploy_environment()
+        self.discover_services()
+        self.prechecks()
+
+    def configure_designate_conf(self):
+        """This method may be overridden by subclasses. You MUST do all
+        customization of self.designate_conf in this method, so that the file
+        is prepared before the images are built.
+        """
+        LOG.info("======== configuring designate.conf ========")
+
+    def init_tmp_dir(self):
+        """There are some docker env config files we'll create dynamically.
+        This is a temporary directory to hold all files created by the tests.
+        """
+        # since COPY in a dockerfile doesn't work with absolute paths, we need
+        # to create temp files in a place docker will find them.
+        tempfile.tempdir = os.path.join(self.carina_dir, 'tmp')
+        try:
+            os.mkdir(tempfile.tempdir)
+        except OSError:
+            pass
+        self.tempdir = tempfile.tempdir
+
+    def new_temp_file(self, prefix, suffix):
+        """Return the name of a new (closed) temp file, in tempfile.tempdir.
+        This ensures the file will be cleaned up after the test runs."""
+        f = tempfile.NamedTemporaryFile(
+            prefix=prefix, suffix=suffix, delete=False
         )
-        LOG.info("api: %s", cls.api.endpoint)
+        f.close()
+        self.addCleanup(utils.cleanup_file, f.name)
+        return f.name
 
-        cls.bind1 = cls.docker_composer.get_host("bind-1", 53, "udp")
-        LOG.info("bind-1: %s", cls.bind1)
+    def init_designate_conf(self):
+        """Create a designate.conf for use by the current test. This will be a
+        randomized filename stored at self.designate_conf.
+        """
+        self.designate_conf = self.new_temp_file("designate", ".conf")
+        LOG.debug("using designate.conf generated at %s", self.designate_conf)
 
-        cls.bind2 = cls.docker_composer.get_host("bind-2", 53, "udp")
-        LOG.info("bind-2: %s", cls.bind2)
+        # initialize designate.conf to some defaults
+        src_path = os.path.join(
+            self.carina_dir, "envs/slappy-bind/designate.conf",
+        )
+        shutil.copyfile(src_path, self.designate_conf)
 
-        LOG.info("updating the default pool")
-        resp = cls.api.update_pool()
-        LOG.debug(utils.resp_to_string(resp))
-        if not resp.ok:
-            msg = "failed to update pool (status=%s)" % resp.status_code
-            raise Exception(msg)
+    def show_designate_conf(self):
+        LOG.debug("designate.conf is at %r:\n%s", self.designate_conf,
+                  open(self.designate_conf, 'r').read())
 
-    @classmethod
-    def prechecks(cls):
+    def init_docker_compose_yaml(self):
+        """Create a designate.yml for use with docker-compose. This will be
+        a randomized filename stored a self.designate_yaml.
+        """
+        self.designate_yaml = self.new_temp_file("designate", ".yml")
+        LOG.debug("using designate.yml generated at %s", self.designate_yaml)
+
+        # initialize the designate.yml, pointing to the right designate.conf
+        src_path = os.path.join(
+            self.carina_dir, "envs/slappy-bind/designate.yml",
+        )
+        content = open(src_path, 'r').read()
+
+        # this is a hack, relying on exact string matching
+        content = content.replace(
+            "envs/slappy-bind/designate.conf",
+            '"%s"' % os.path.relpath(self.designate_conf, self.carina_dir)
+        )
+        LOG.debug("%s has content:\n%s", self.designate_conf, content)
+
+        open(self.designate_yaml, 'w').write(content)
+
+    def tearDown(self):
+        LOG.info("======== base class teardown ========")
+        self.cleanup_environment()
+        super(BaseTest, self).tearDown()
+
+    def discover_services(self):
+        LOG.info("======== discover service locations ========")
+        self.api = designate.API(
+            "http://%s" % self.docker_composer.get_host("api", 9001)
+        )
+        LOG.info("api: %s", self.api.endpoint)
+
+        self.bind1 = self.docker_composer.get_host("bind-1", 53, "udp")
+        LOG.info("bind-1: %s", self.bind1)
+
+        self.bind2 = self.docker_composer.get_host("bind-2", 53, "udp")
+        LOG.info("bind-2: %s", self.bind2)
+
+    def deploy_environment(self):
+        LOG.info("======== deploying env (%s) ========", self.project_name)
+        _, _, ret = self.docker_composer.build()
+        self.assertEqual(ret, 0)
+
+        _, _, ret = self.docker_composer.up()
+        self.assertEqual(ret, 0)
+
+        sleep_time = 15
+        LOG.info("waiting %s seconds for services to start up", sleep_time)
+        time.sleep(15)
+
+    def cleanup_environment(self):
+        LOG.info("======== cleaning up env (%s) ========", self.project_name)
+        _, _, ret = self.docker_composer.down()
+        if ret != 0:
+            LOG.error("FAILED TO CLEANUP ENV (project=%s)", self.project_name)
+            LOG.error("TRY `docker-compose -p %s down`", self.project_name)
+        self.assertEqual(
+            ret, 0, "FAILED TO CLEANUP ENV (project=%s)" % self.project_name
+        )
+
+    def prechecks(self):
         """Do quick checks of the api + nameservers"""
         LOG.info("======== checking environment preconditions ========")
         LOG.info("checking the api by listing zones")
-        resp = cls.api.list_zones()
+        resp = self.api.list_zones()
         LOG.debug(utils.resp_to_string(resp))
         assert resp.ok
 
-        # these raise exceptions on timeouts
+        # these digs raise exceptions on timeouts
         LOG.info("checking bind-1 by digging it")
-        utils.dig("poo.com.", cls.bind1, "ANY")
+        utils.dig("poo.com.", self.bind1, "ANY")
 
         LOG.info("checking bind-2 by digging it")
-        utils.dig("poo.com.", cls.bind2, "ANY")
+        utils.dig("poo.com.", self.bind2, "ANY")
 
         LOG.info("all prechecks have passed!")
 
@@ -93,41 +208,49 @@ class BaseTest(unittest.TestCase):
             self.fail("failed to delete zone %s", name)
         LOG.debug(utils.resp_to_string(resp))
 
-    def wait_for_zone_to_error(self, name, zid, timeout=30):
+    def wait_for_zone_to_error(self, name, zid):
         """Wait for the given zone to go to ERROR. Fail the test if we fail to
         timeout before seeing an ERROR status.
         """
         LOG.info("waiting for zone %s to go to ERROR...", name)
         resp = waiters.wait_for_status(
-            lambda: self.api.get_zone(zid), ["ERROR", "ACTIVE"], timeout,
+            lambda: self.api.get_zone(zid), ["ERROR", "ACTIVE"], self.interval,
+            self.timeout,
         )
         LOG.info("...done waiting for zone %s", name)
         LOG.debug(utils.resp_to_string(resp))
-        if resp.json()["status"] != "ERROR":
-            self.fail("zone %s failed to go to ERROR" % name)
+        self.assertEqual(
+            resp.json()["status"], "ERROR",
+            "zone %s failed to go to ERROR (timeout=%s)" % (name, self.timeout)
+        )
 
-    def wait_for_zone_to_active(self, name, zid, timeout=30):
+    def wait_for_zone_to_active(self, name, zid):
         """Wait for the given zone to go to ACTIVE. Fail the test if we timeout
         before seeing an ACTIVE status.
         """
         LOG.info("waiting for zone %s to go to ACTIVE...", name)
         resp = waiters.wait_for_status(
-            lambda: self.api.get_zone(zid), ["ACTIVE"], timeout,
+            lambda: self.api.get_zone(zid), ["ACTIVE"], self.interval,
+            self.timeout
         )
         LOG.info("...done waiting for zone %s", name)
         LOG.debug(utils.resp_to_string(resp))
-        if resp.json()["status"] != "ACTIVE":
-            self.fail("zone %s failed to go to ACTIVE" % name)
+        self.assertEqual(
+            resp.json()["status"], "ACTIVE",
+            "zone %s failed to go ACTIVE (timeout=%s)" % (name, self.timeout)
+        )
 
-    def wait_for_zone_to_404(self, name, zid, timeout=30):
+    def wait_for_zone_to_404(self, name, zid):
         """Wait for the given zone to return a 404. Fail the test if we timeout
         before seeing a 404 status code.
         """
         LOG.info("waiting for zone %s to 404...", name)
-        resp = waiters.wait_for_404(lambda: self.api.get_zone(zid), timeout=60)
+        resp = waiters.wait_for_404(
+            lambda: self.api.get_zone(zid), self.interval, self.timeout,
+        )
         LOG.info("...done waiting for zone %s", name)
         LOG.debug(utils.resp_to_string(resp))
-        assert resp.status_code == 404
-        if resp.status_code != 404:
-            LOG.warning("resp.status_code is %s", resp.status_code)
-            self.fail("zone %s failed to eventually 404" % name)
+        self.assertEqual(
+            resp.status_code, 404,
+            "zone %s failed to 404 (timeout=%s)" % (name, self.timeout)
+        )

--- a/ruiner/test/test_ini.py
+++ b/ruiner/test/test_ini.py
@@ -1,0 +1,68 @@
+import tempfile
+import unittest
+import logging
+
+from ruiner.common.ini import IniFile
+
+LOG = logging.getLogger(__name__)
+
+
+class TestIniFile(unittest.TestCase):
+
+    def setUp(self):
+        self.tempfile = tempfile.NamedTemporaryFile()
+        self.filename = self.tempfile.name
+        LOG.info("using tempfile %s", self.filename)
+        self.inifile = IniFile(self.filename)
+
+    def assertFileContains(self, expected):
+        content = open(self.filename, 'r').read()
+        self.assertEqual(content, expected)
+
+    def test_iniset_in_empty_file(self):
+        self.inifile.set("hello", "mykey", "12345")
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 12345\n\n"
+        )
+
+        self.inifile.set("hello", "mykey", "45678")
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 45678\n\n"
+        )
+
+        self.inifile.set("hello", "otherkey", '\"abcde\"')
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 45678\n"
+            "otherkey = \"abcde\"\n\n"
+        )
+
+        self.inifile.set("goodbye", "mykey", "")
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 45678\n"
+            "otherkey = \"abcde\"\n\n"
+            "[goodbye]\n"
+            "mykey = \n\n"
+        )
+
+        self.inifile.set("goodbye", "mykey", "value")
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 45678\n"
+            "otherkey = \"abcde\"\n\n"
+            "[goodbye]\n"
+            "mykey = value\n\n"
+        )
+
+        self.inifile.set("goodbye", "yellow", 1)
+        self.assertFileContains(
+            "[hello]\n"
+            "mykey = 45678\n"
+            "otherkey = \"abcde\"\n\n"
+            "[goodbye]\n"
+            "mykey = value\n"
+            "yellow = 1\n\n"
+        )

--- a/ruiner/test/test_nameserver_dies.py
+++ b/ruiner/test/test_nameserver_dies.py
@@ -8,13 +8,11 @@ class TestNameserverDies(base.BaseTest):
 
     def setUp(self):
         super(TestNameserverDies, self).setUp()
-        self.docker_composer.unpause("bind-2")
-        self.prechecks()
         LOG.info("======== test start ========")
 
     def tearDown(self):
         self.docker_composer.unpause("bind-2")
-        super(TestNameserverDies, self).setUp()
+        super(TestNameserverDies, self).tearDown()
 
     def test_create_zone_while_nameserver_is_down(self):
         """Create a zone while a nameserver is down. Check the zone goes to

--- a/ruiner/test/test_quota.py
+++ b/ruiner/test/test_quota.py
@@ -1,0 +1,31 @@
+from ruiner.common import utils
+from ruiner.test import base
+from ruiner.common.ini import IniFile
+
+LOG = utils.create_logger(__name__)
+
+
+class TestZonePerTenantQuota(base.BaseTest):
+
+    def configure_designate_conf(self):
+        super(TestZonePerTenantQuota, self).configure_designate_conf()
+
+        self.quota_zones = 3
+
+        conf = IniFile(self.designate_conf)
+        conf.set("DEFAULT", "quota_zones", self.quota_zones)
+
+    def test_quota_zones(self):
+        # create enough zones to reach, but not exceed, the quota
+        zones = []
+        for _ in range(self.quota_zones):
+            zones.append(self.create_zone())
+        for zone in zones:
+            self.wait_for_zone_to_active(*zone)
+
+        # create an additional zone. check that it 413s.
+        resp = self.api.create_zone()
+        LOG.debug(utils.resp_to_string(resp))
+        self.assertEqual(resp.status_code, 413)
+        self.assertEqual(resp.json()["code"], 413)
+        self.assertEqual(resp.json()["type"], "over_quota")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,6 @@ colorlog==2.6.1
 dnspython==1.12.0
 py==1.4.31
 pytest==2.9.1
+pytest-xdist==1.14
 requests==2.9.1
+oslo.config==3.9.0

--- a/tools/docker-cleanup.sh
+++ b/tools/docker-cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# This script can be used to manually cleanup docker environments left around
+# by designate-ruiner. Normally, the ruiner tests will cleanup themselves, but
+# things often don't work.
+
+COMPOSE_FILES="-f base.yml -f envs/slappy-bind/designate.yml -f envs/slappy-bind/bind.yml"
+
+# for use with the `docker-compose -p`
+COMPOSE_PROJECT_TAG='ruin_designate'
+
+# docker-compose uses the project name to assign unique container names
+# for some reason, underscores and hyphens get stripped when this happens
+MUNGED_CONTAINER_TAG=`echo $COMPOSE_PROJECT_TAG | sed 's/_\|-//g'`
+
+DESIGNATE_CARINA_DIR='./designate-carina'
+pushd $DESIGNATE_CARINA_DIR
+
+# figure out the random tag for a project
+RANDOM_TAGS=`docker ps --format "{{.Names}}" | grep $MUNGED_CONTAINER_TAG \
+    | cut -d'_' -f1 | sed 's/ruindesignate//g' | uniq`
+
+for random_tag in $RANDOM_TAGS; do
+    COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_TAG}_$random_tag"
+    set -x
+    docker-compose $COMPOSE_FILES -p $COMPOSE_PROJECT_NAME down
+    set +x
+done
+
+popd

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27, flake8
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
-commands = py.test -sv ./ruiner/test
+commands = py.test -n 2 -v ./ruiner/test
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
- Add ini utility for editing designate.conf
- Deploy a new docker env in the test setup. Add DockerComposer.down()
  so that cleaning up docker envs works.
- Each test uses a unique designate.conf, docker-compose.yml. Add quota
  tests to demonstrate this.
- Add a tool to cleanup leftover docker envs
- Bump the designate-carina version to support pools.yml, and so we
  don't have multiple memcached containers trying to bind on
  0.0.0.0:11211.
- Don't run prechecks twice.