### PR TITLE
Properly clear os.environ when patched in unit tests

### DIFF
--- a/ruiner/test/test_docker_composer.py
+++ b/ruiner/test/test_docker_composer.py
@@ -32,18 +32,22 @@ class TestDockerComposer(unittest.TestCase):
         self.dc._run_cmd.assert_called_with(
             'docker-compose', 'port', '--protocol', 'udp', 'bind-1', 53)
 
+    # make sure DOCKER_HOST is not set
+    @mock.patch.dict(os.environ, {}, clear=True)
     def test_get_host(self):
         self.dc.port = mock.Mock(return_value=('0.0.0.0:1234', '', 0))
         self.assertEqual(self.dc.get_host('api', 0), '127.0.0.1:1234')
         self.dc.port.assert_called_with('api', 0, None)
 
+    @mock.patch.dict(os.environ, {}, clear=True)
     def test_get_host_with_protocol(self):
         self.dc.port = mock.Mock(return_value=('0.0.0.0:5555', '', 0))
         self.assertEqual(self.dc.get_host('central', 1122, 'udp'),
                          '127.0.0.1:5555')
         self.dc.port.assert_called_with('central', 1122, 'udp')
 
-    @mock.patch.dict(os.environ, {'DOCKER_HOST': 'tcp://1.2.3.4:2379'})
+    @mock.patch.dict(os.environ, {'DOCKER_HOST': 'tcp://1.2.3.4:2379'},
+                     clear=True)
     def test_get_host_respects_docker_host(self):
         self.dc.port = mock.Mock(return_value=('0.0.0.0:5678', '', 0))
         self.assertEqual(self.dc.get_host('api', 0), '1.2.3.4:5678')


### PR DESCRIPTION
This fixes an issue where unit tests allowed rogue environment variables
through, which caused the get_host() tests to fail since get_host()
looks at DOCKER_HOST.