### PR TITLE
Make the log colors configurable for jenkins

### DIFF
--- a/ruiner/common/config.py
+++ b/ruiner/common/config.py
@@ -10,6 +10,7 @@ def get_location(name='ruiner.conf'):
     return path
 
 cfg.CONF.register_group(cfg.OptGroup('ruiner'))
+cfg.CONF.register_group(cfg.OptGroup('ruiner:colorlog'))
 
 cfg.CONF.register_opts([
     cfg.IntOpt("interval", default=3),
@@ -18,5 +19,14 @@ cfg.CONF.register_opts([
                help="How to wait after `docker-compose up` for services to "
                     "be ready."),
 ], group='ruiner')
+
+cfg.CONF.register_opts([
+    cfg.StrOpt('debug_color', default='white'),
+    cfg.StrOpt('info_color', default='green'),
+    cfg.StrOpt('warning_color', default='yellow'),
+    cfg.StrOpt('error_color', default='red'),
+    cfg.StrOpt('critical_color', default='red'),
+], group='ruiner:colorlog')
+
 
 cfg.CONF(args=[], default_config_files=[get_location()])

--- a/ruiner/common/utils.py
+++ b/ruiner/common/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import subprocess
 import random
 import string
@@ -10,14 +11,23 @@ import dns.message
 import dns.rdatatype
 import dns.query
 
-import logging
 import colorlog
+
+from ruiner.common.config import cfg
 
 
 def create_logger(name):
+    colors = cfg.CONF['ruiner:colorlog']
     stream = logging.StreamHandler()
     stream.setFormatter(colorlog.ColoredFormatter(
-         '%(log_color)s%(asctime)s [%(levelname)s] %(message)s'
+        '%(log_color)s%(asctime)s [%(levelname)s] %(message)s',
+        log_colors={
+            'DEBUG': colors.debug_color,
+            'INFO': colors.info_color,
+            'WARNING': colors.warning_color,
+            'ERROR': colors.error_color,
+            'CRITICAL': colors.critical_color,
+        }
     ))
 
     logger = logging.getLogger(name)

--- a/ruiner/test/test_log_colors.py
+++ b/ruiner/test/test_log_colors.py
@@ -1,0 +1,18 @@
+import unittest
+from ruiner.common import utils
+
+
+class TestLogColor(unittest.TestCase):
+
+    def test_log_color(self):
+        # this "test" doesn't check anything, but is useful for checking
+        # terminal colors based on the config in jenkins
+        #
+        #   py.test -sv -k test_log_color ruiner/test/
+        #
+        log = utils.create_logger('test_log_color')
+        log.info('info')
+        log.debug('debug')
+        log.warning('warning')
+        log.critical('critical')
+        log.error('error')


### PR DESCRIPTION
`colorlog` defaults to `white` for debug. This doesn't work well in jenkins which has white backgrounds. We can now set `debug_color = <color>` (in addition to configs for the other log levels). If `debug_color = reset` that will clear any colorization, which is pretty useful.