### PR TITLE
Tag built docker images to be unique to the test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: designate-carina ruin
 
 designate-carina:
 	git clone git@github.com:rackerlabs/designate-carina.git
-	cd designate-carina && git checkout 538b0bf5f70d0279401be6a2072a32b8f2f2fba9
+	cd designate-carina && git checkout 4da2d7d137c41e61fb801e39fa2fc8ccc1e98392
 
 lint:
 	tox -e flake8

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: designate-carina ruin
 
 designate-carina:
 	git clone git@github.com:rackerlabs/designate-carina.git
-	cd designate-carina && git checkout 4da2d7d137c41e61fb801e39fa2fc8ccc1e98392
+	cd designate-carina && git checkout 763dfa4a123def68b68fcfc740555309e21956ca
 
 lint:
 	tox -e flake8

--- a/ruiner/common/utils.py
+++ b/ruiner/common/utils.py
@@ -142,7 +142,7 @@ def require_success(result):
 
 def random_project_name():
     chars = "".join(random.choice(string.ascii_letters) for _ in range(8))
-    return "ruin_designate_%s" % chars
+    return ("ruin_designate_%s" % chars).lower()
 
 
 def cleanup_file(filename):

--- a/ruiner/templates/designate.yml.jinja2
+++ b/ruiner/templates/designate.yml.jinja2
@@ -1,0 +1,47 @@
+version: '2'
+
+services:
+  designate-base:
+    build:
+      args:
+        DESIGNATE_CONF: {{ DESIGNATE_CONF }}
+        POOLS_YAML: {{ POOLS_YAML }}
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+
+  mysql:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    ports:
+      - "3306"
+    command: /usr/bin/mysqld_safe
+
+  rabbit:
+    image: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: designate
+      RABBITMQ_DEFAULT_PASS: designate
+    ports:
+      - "5672"
+
+  api:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    ports:
+      - "9001"
+    command: designate-api
+
+  central:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    command: designate-central
+
+  mdns:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    ports:
+      - "5354"
+    command: designate-mdns
+
+  poolmanager:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    command: designate-pool-manager
+
+  zonemanager:
+    image: 'designate-base:{{ RUINER_PROJECT }}'
+    command: designate-zone-manager

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist==1.14
 requests==2.9.1
 oslo.config==3.9.0
 mock==2.0.0
+Jinja2==2.8


### PR DESCRIPTION
This ensures that, when docker images are built in parallel, each one
gets a unique name so (I think) we won't run into failures because
image names are being reused.