### PR TITLE
Add tests of threshold percentage behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.cache*
 designate-carina/
 *.pyc
-/.venv
-/.tox
+.venv
+.tox
 ruiner.conf
+ruiner-logs/

--- a/ruiner/common/designate.py
+++ b/ruiner/common/designate.py
@@ -8,7 +8,8 @@ LOG = utils.create_logger(__name__)
 
 class Client(object):
 
-    def __init__(self, endpoint, headers=None, timeout=60):
+    def __init__(self, endpoint, headers=None, timeout=3, retries=5):
+        self.retries = retries
         self.endpoint = endpoint
         self.timeout = timeout
         self.headers = headers or {}
@@ -21,25 +22,33 @@ class Client(object):
         kwargs['headers'] = headers
         return args, kwargs
 
+    def _do_request(self, f):
+        for _ in range(self.retries):
+            try:
+                return f()
+            except requests.Timeout as e:
+                LOG.warning(str(e))
+        raise Exception("Request timed out after %s retries", self.retries)
+
     def get(self, *args, **kwargs):
         args, kwargs = self._inject_default_request_args(*args, **kwargs)
-        return requests.get(*args, **kwargs)
+        return self._do_request(lambda: requests.get(*args, **kwargs))
 
     def post(self, *args, **kwargs):
         args, kwargs = self._inject_default_request_args(*args, **kwargs)
-        return requests.post(*args, **kwargs)
+        return self._do_request(lambda: requests.post(*args, **kwargs))
 
     def put(self, *args, **kwargs):
         args, kwargs = self._inject_default_request_args(*args, **kwargs)
-        return requests.put(*args, **kwargs)
+        return self._do_request(lambda: requests.put(*args, **kwargs))
 
     def patch(self, *args, **kwargs):
         args, kwargs = self._inject_default_request_args(*args, **kwargs)
-        return requests.patch(*args, **kwargs)
+        return self._do_request(lambda: requests.patch(*args, **kwargs))
 
     def delete(self, *args, **kwargs):
         args, kwargs = self._inject_default_request_args(*args, **kwargs)
-        return requests.delete(*args, **kwargs)
+        return self._do_request(lambda: requests.delete(*args, **kwargs))
 
 
 class API(Client):

--- a/ruiner/common/docker.py
+++ b/ruiner/common/docker.py
@@ -60,13 +60,18 @@ class DockerComposer(object):
         LOG.info("stopping docker containers")
         return self._run_cmd("docker-compose", "down")
 
-    def pause(self, container):
-        LOG.info("pausing container %s", container)
-        return self._run_cmd("docker-compose", "pause", container)
+    def kill(self, container):
+        LOG.info("killing container %s", container)
+        return self._run_cmd("docker-compose", "kill", container)
 
-    def unpause(self, container):
-        LOG.info("unpausing container %s", container)
-        return self._run_cmd("docker-compose", "unpause", container)
+    def start(self, container):
+        LOG.info("starting container %s", container)
+        return self._run_cmd("docker-compose", "start", container)
+
+    def exec_(self, container, cmd):
+        LOG.info("running '%s' in container %s", cmd, container)
+        cmd = cmd.split(' ')
+        return self._run_cmd("docker-compose", "exec", container, *cmd)
 
     def port(self, container, port, protocol=None):
         LOG.info("getting port for %s:%s", container, port)

--- a/ruiner/common/ini.py
+++ b/ruiner/common/ini.py
@@ -21,6 +21,12 @@ class IniFile(object):
             config.set(section_name, key, value)
         self._write(config)
 
+    def get(self, section_name, key):
+        return self._read().get(section_name, key)
+
+    def getint(self, section_name, key):
+        return self._read().getint(section_name, key)
+
     def _write(self, config):
         with open(self.filename, 'w') as f:
             config.write(f)

--- a/ruiner/common/utils.py
+++ b/ruiner/common/utils.py
@@ -6,7 +6,6 @@ import random
 import re
 import string
 import os
-import pprint
 import tempfile
 
 import dns
@@ -97,7 +96,7 @@ def resp_to_string(resp):
     else:
         try:
             data = json.loads(resp.text)
-            msg += "\n{0}".format(pprint.pformat(data, indent=2))
+            msg += "\n{0}".format(json.dumps(data, indent=2))
         except:
             msg += "\n{0}".format(resp.text)
 

--- a/ruiner/common/utils.py
+++ b/ruiner/common/utils.py
@@ -6,6 +6,7 @@ import random
 import re
 import string
 import os
+import pprint
 import tempfile
 
 import dns
@@ -95,7 +96,8 @@ def resp_to_string(resp):
         msg += "\n{0}... <truncated>".format(resp.text[:1000])
     else:
         try:
-            msg += "\n{0}".format(json.dumps(resp.text, indent=2))
+            data = json.loads(resp.text)
+            msg += "\n{0}".format(pprint.pformat(data, indent=2))
         except:
             msg += "\n{0}".format(resp.text)
 
@@ -121,9 +123,7 @@ def dig(zone_name, nameserver, rdatatype):
         rdatatype = dns.rdatatype.from_text(rdatatype)
 
     query = prepare_query(zone_name, rdatatype)
-    resp = dns.query.udp(query, host, timeout=1, port=port)
-    LOG.debug("\n%s", resp)
-    return resp
+    return dns.query.udp(query, host, timeout=1, port=port)
 
 
 def prepare_query(zone_name, rdatatype):

--- a/ruiner/common/waiters.py
+++ b/ruiner/common/waiters.py
@@ -1,5 +1,7 @@
 import time
 
+from ruiner.common import utils
+
 
 def wait_for_status(api_call, statuses, interval, timeout):
     """Wait for the zone to show the status
@@ -32,4 +34,38 @@ def wait_for_404(api_call, interval, timeout):
         if end < time.time():
             break
         time.sleep(interval)
+    return resp
+
+
+def wait_for_zone_on_nameserver(name, ns, interval, timeout):
+    """Wait for the name to show up on the nameserver. This does not catch
+    timeout exceptions"""
+
+    end = time.time() + timeout
+    while True:
+        resp = utils.dig(name, ns, "ANY")
+
+        if bool(resp.answer):
+            break
+        if end < time.time():
+            break
+        time.sleep(interval)
+
+    return resp
+
+
+def wait_for_zone_removed_from_nameserver(name, ns, interval, timeout):
+    """Wait for the name to be removed from the nameserver. This does not catch
+    timeout exceptions"""
+
+    end = time.time() + timeout
+    while True:
+        resp = utils.dig(name, ns, "ANY")
+
+        if not bool(resp.answer):
+            break
+        if end < time.time():
+            break
+        time.sleep(interval)
+
     return resp

--- a/ruiner/common/waiters.py
+++ b/ruiner/common/waiters.py
@@ -37,7 +37,7 @@ def wait_for_404(api_call, interval, timeout):
     return resp
 
 
-def wait_for_zone_on_nameserver(name, ns, interval, timeout):
+def wait_for_name_on_nameserver(name, ns, interval, timeout):
     """Wait for the name to show up on the nameserver. This does not catch
     timeout exceptions"""
 
@@ -54,7 +54,7 @@ def wait_for_zone_on_nameserver(name, ns, interval, timeout):
     return resp
 
 
-def wait_for_zone_removed_from_nameserver(name, ns, interval, timeout):
+def wait_for_name_removed_from_nameserver(name, ns, interval, timeout):
     """Wait for the name to be removed from the nameserver. This does not catch
     timeout exceptions"""
 

--- a/ruiner/test/base.py
+++ b/ruiner/test/base.py
@@ -373,13 +373,13 @@ class BaseTest(unittest.TestCase):
             "zone %s failed to 404 (timeout=%s)" % (name, self.timeout)
         )
 
-    def wait_for_zone_on_nameserver(self, name, service_name):
+    def wait_for_name_on_nameserver(self, name, service_name):
         """Wait for a successful, non-empty response from the nameserver"""
         LOG.info("waiting for %s to go live on nameserver %s...", name,
                  service_name)
 
         host = self.services[service_name]
-        resp = waiters.wait_for_zone_on_nameserver(
+        resp = waiters.wait_for_name_on_nameserver(
             name, host, self.interval, self.timeout,
         )
 
@@ -398,12 +398,12 @@ class BaseTest(unittest.TestCase):
             ),
         )
 
-    def wait_for_zone_removed_from_nameserver(self, name, service_name):
+    def wait_for_name_removed_from_nameserver(self, name, service_name):
         LOG.info("waiting for %s to be removed from nameserver %s", name,
                  service_name)
 
         host = self.services[service_name]
-        resp = waiters.wait_for_zone_removed_from_nameserver(
+        resp = waiters.wait_for_name_removed_from_nameserver(
             name, host, self.interval, self.timeout,
         )
 

--- a/ruiner/test/test_nameserver_recovery.py
+++ b/ruiner/test/test_nameserver_recovery.py
@@ -67,11 +67,11 @@ class TestThresholdPercentage(base.BaseTest):
         # check that a zone goes to active and is really queryable on bind-1
         name, zid = self.create_zone()
         self.wait_for_zone_to_active(name, zid)
-        self.wait_for_zone_on_nameserver(name, 'bind-1')
+        self.wait_for_name_on_nameserver(name, 'bind-1')
 
         # restart the other nameserver. check the zone shows up there.
         self.restart_nameserver('bind-2')
-        self.wait_for_zone_on_nameserver(name, 'bind-2')
+        self.wait_for_name_on_nameserver(name, 'bind-2')
 
         # check the zone is still active
         LOG.info("checking the zone is (still) active")
@@ -79,25 +79,46 @@ class TestThresholdPercentage(base.BaseTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['status'], 'ACTIVE')
 
+    def test_recovery_of_recordset_create_with_low_threshold_percentage(self):
+        """Create a recordset while a nameserver is down. Check the recordset
+        gets to the live nameserver and goes active (due to threshold
+        percentage). Restart the nameserver. Check the recordset is on the
+        nameserver.
+        """
+        zname, zid = self._create_zone()
+
+        # kill a nameserver. check that a create goes to active.
+        self.kill_nameserver('bind-2')
+        rrname, rrid = self.create_recordset(zname, zid)
+        self.wait_for_zone_to_active(zname, zid)
+        self.wait_for_name_on_nameserver(rrname, 'bind-1')
+
+        # restart the nameserver. the record must be found on all nameservers.
+        self.restart_nameserver('bind-2')
+        self.wait_for_name_on_nameserver(rrname, 'bind-2')
+
     def test_recovery_of_zone_delete_with_low_threshold_percentage(self):
         """Delete an active zone while a nameserver is down. Check the zone is
         removed from another nameserver but that zone 404s (due to the
         threshold percentage). Restore the nameserver. Check the zone is
         removed from the remaining nameservers."""
-
-        # create a zone
-        name, zid = self.create_zone()
-        self.wait_for_zone_to_active(name, zid)
-        self.wait_for_zone_on_nameserver(name, 'bind-1')
-        self.wait_for_zone_on_nameserver(name, 'bind-2')
+        name, zid = self._create_zone()
 
         # kill a nameserver. check that a delete leads to 404.
         self.kill_nameserver('bind-2')
         self.delete_zone(name, zid)
         self.wait_for_zone_to_404(name, zid)
-        self.wait_for_zone_removed_from_nameserver(name, 'bind-1')
+        self.wait_for_name_removed_from_nameserver(name, 'bind-1')
 
         # restart the nameserver. the zone must be removed from all nameservers
         # (within our timeout)
         self.restart_nameserver('bind-2')
-        self.wait_for_zone_removed_from_nameserver(name, 'bind-2')
+        self.wait_for_name_removed_from_nameserver(name, 'bind-2')
+
+    def _create_zone(self):
+        # create a zone
+        name, zid = self.create_zone()
+        self.wait_for_zone_to_active(name, zid)
+        self.wait_for_name_on_nameserver(name, 'bind-1')
+        self.wait_for_name_on_nameserver(name, 'bind-2')
+        return name, zid

--- a/ruiner/test/test_nameserver_recovery.py
+++ b/ruiner/test/test_nameserver_recovery.py
@@ -7,10 +7,6 @@ LOG = utils.create_logger(__name__)
 
 class TestNameserverRecovery(base.BaseTest):
 
-    def tearDown(self):
-        self.docker_composer.unpause("bind-2")
-        super(TestNameserverRecovery, self).tearDown()
-
     def test_create_zone_while_nameserver_is_down(self):
         """Create a zone while a nameserver is down. Check the zone goes to
         ERROR. Bring the nameserver back up. Check the zone goes to ACTIVE.
@@ -102,5 +98,6 @@ class TestThresholdPercentage(base.BaseTest):
         self.wait_for_zone_removed_from_nameserver(name, 'bind-1')
 
         # restart the nameserver. the zone must be removed from all nameservers
+        # (within our timeout)
         self.restart_nameserver('bind-2')
         self.wait_for_zone_removed_from_nameserver(name, 'bind-2')

--- a/tools/docker-cleanup.sh
+++ b/tools/docker-cleanup.sh
@@ -34,8 +34,10 @@ fi
 for random_tag in $RANDOM_TAGS; do
     COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_TAG}_$random_tag"
     set -x
-    docker-compose $COMPOSE_FILES -p $COMPOSE_PROJECT_NAME down
+    docker-compose $COMPOSE_FILES -p $COMPOSE_PROJECT_NAME down &
     set +x
 done
+
+wait
 
 popd

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27, flake8
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
-commands = py.test -n 2 -v ./ruiner/test
+commands = py.test -n 4 -v ./ruiner/test
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Dependent on https://github.com/rackerlabs/designate-ruiner/pull/7

- [x] Use `docker kill` instead of `docker pause`. This actually kills the processes rather than suspending them (which leads to a false sense of resiliency in designate).
- [x] Add a low threshold percentage test for zone creates
- [x] Add a low threshold percentage test for zone updates
- [x] Add a low threshold percentage test for zone deletes
- [x] Update the API client to retry api requests a few times (I sometimes saw timeouts on api requests).
