### PR TITLE
Rework logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ designate-carina/
 .tox
 ruiner.conf
 ruiner-logs/
+*egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ designate-carina/
 ruiner.conf
 ruiner-logs/
 *egg-info/
+index.html

--- a/README.md
+++ b/README.md
@@ -48,3 +48,53 @@ The easiest away is using `tox`,
     $ tox
 
 This will run the pep8 checks and the reliability tests for designate.
+
+
+Using the `ruiner` script
+-------------------------
+
+Optionally, you may use the `ruiner` script to run tests as well. This is a
+pure wrapper around `py.test`.
+
+To install the `ruiner` script:
+
+    $ pip install test-requirements.txt
+    $ pip install .
+
+To run tests:
+
+    $ ruiner py.test ./ruiner/test/
+
+Show all log dirs from previous test runs (most recent first):
+
+    $ ruiner logs
+    ./ruiner-logs/2016-08-10_18_18_03.688111
+    ./ruiner-logs/2016-08-10_18_02_36.744491
+    ./ruiner-logs/2016-08-10_18_01_38.265400
+    ...
+
+Show the log dir from the last run:
+
+    $ ruiner logs --last
+    ./ruiner-logs/2016-08-10_18_18_03.688111
+
+List all log files from the last run:
+
+     $ ruiner logs --last -r
+    ./ruiner-logs/2016-08-10_18_18_03.688111/master.log
+    ./ruiner-logs/2016-08-10_18_18_03.688111/ruiner.test.test_docker_composer.TestDockerComposer.test_args/master.log
+    ./ruiner-logs/2016-08-10_18_18_03.688111/ruiner.test.test_docker_composer.TestDockerComposer.test_get_host/master.log
+    ./ruiner-logs/2016-08-10_18_18_03.688111/ruiner.test.test_docker_composer.TestDockerComposer.test_get_host_respects_docker_host/master.log
+    ...
+
+
+### Why to use the `ruiner` script to run `designate-ruiner` tests
+
+- It is not a custom test runner. `ruiner py.test <args>` uses `py.test`. All
+args (including flags) are passed along to `py.test` unmodified, so all
+`py.test` functionality is available.
+- It ensures timestamped log directories, in a way that works with multiple
+processes. By default, your logs are placed in `<log-dir>/latest/`. With
+`ruiner`, a new directory is created for each run, like
+`<log-dir>/2016-08-10_18_18_03.688111/`.
+- It supports listing logs from previous runs.

--- a/ruiner/common/runner.py
+++ b/ruiner/common/runner.py
@@ -47,13 +47,33 @@ def logs(args):
     entries = [(d, os.path.getmtime(d)) for d in dirs]
     entries.sort(key=lambda x: x[1], reverse=True)
 
+    result_dirs = []
     if args.want_last:
-        print entries[0][0]
+        result_dirs.append(entries[0][0])
     else:
-        for d, _ in entries:
+        result_dirs.extend([d for d, _ in entries])
+
+    if args.want_recursive:
+        for f in recursive_list(result_dirs):
+            print f
+    else:
+        for d in result_dirs:
             print d
 
     return 0
+
+
+def recursive_list(dirs):
+    """Return a sorted, recursive list of plain files in the directories"""
+    result = []
+    frontier = list(dirs)
+    while frontier:
+        for current, subdirs, files in os.walk(frontier.pop(0)):
+            frontier.extend(subdirs)
+            for f in files:
+                result.append(os.path.join(current, f))
+    result.sort()
+    return result
 
 
 def parse_args():
@@ -91,6 +111,9 @@ of test logs easier.""")
     log_parser.add_argument(
         '--last', dest='want_last', action='store_true',
         help="only show the most recent log entry")
+    log_parser.add_argument(
+        '-r', dest='want_recursive', action='store_true',
+        help="recursively list all files")
 
     # set the handler for the pytest command. this has no subparser
     pytest_sub_parser.set_defaults(

--- a/ruiner/common/runner.py
+++ b/ruiner/common/runner.py
@@ -1,0 +1,127 @@
+import argparse
+from datetime import datetime
+import os
+import subprocess
+import signal
+import sys
+
+
+from ruiner.common.config import cfg
+
+
+def pytest(args):
+    """Run tests with py.test, ensuring all py.test processes use the same
+    timestamp for the test run"""
+    RUINER_TEST_START_TIME = datetime.utcnow().strftime('%Y-%m-%d_%H_%M_%S.%f')
+
+    env = dict(os.environ)
+    env.update({
+        'RUINER_TEST_START_TIME': RUINER_TEST_START_TIME,
+    })
+
+    try:
+        p = subprocess.Popen(['py.test'] + list(args), env=env)
+        p.wait()
+    except KeyboardInterrupt:
+        p.send_signal(signal.SIGINT)
+        p.wait()
+        sys.exit(1)
+
+    return p.returncode
+
+
+def logs(args):
+    """List logs from previous ruiner test runs."""
+    log_dir = cfg.CONF.ruiner.log_dir
+
+    if not os.path.exists(log_dir):
+        print '{} does not exist'.format(log_dir)
+        return 1
+
+    dirs = [os.path.join(log_dir, d) for d in os.listdir(log_dir)]
+    if not dirs:
+        print 'No previous logs in {}'.format(log_dir)
+        return 1
+
+    # sort log dirs by time
+    entries = [(d, os.path.getmtime(d)) for d in dirs]
+    entries.sort(key=lambda x: x[1], reverse=True)
+
+    if args.want_last:
+        print entries[0][0]
+    else:
+        for d, _ in entries:
+            print d
+
+    return 0
+
+
+def parse_args():
+    # We need a bit of extra stuff here in order to forward arbitrary flags to
+    # a subprocess. For example, with:
+    #
+    #   ruiner pytest --collect-only
+    #
+    # argparse will complain because we didn't define a `--collect-only` flag.
+    # However, we need to forward all remaining args along to py.test. To work
+    # around this:
+    #
+    #   - Require a strict format of `<script> <command> [args...]`. No flags
+    #   are allowed between the script and the command.
+    #   - The base/top-level parser is given just the command to parse.
+    #   - Each command gets its own special subparser.
+    #
+    # This lets us easily remove the subparser for the `pytest` command, to
+    # then forward all args without argparse complaining, and without losing
+    # argparse everywhere.
+    parser = argparse.ArgumentParser(description="""
+A tiny wrapper for the designate-ruiner tests, to make management and discovery
+of test logs easier.""")
+
+    # declare subparsers here
+    subparsers = parser.add_subparsers()
+    pytest_sub_parser = subparsers.add_parser(
+        'py.test', help='Run tests with py.test')
+    log_sub_parser = subparsers.add_parser(
+        'logs', help='List logs from previous test runs')
+
+    # the actual subparser for the logs command
+    log_parser = argparse.ArgumentParser(
+        description="List logs from previous test runs")
+    log_parser.add_argument(
+        '--last', dest='want_last', action='store_true',
+        help="only show the most recent log entry")
+
+    # set the handler for the pytest command. this has no subparser
+    pytest_sub_parser.set_defaults(
+        handler=lambda: invoke_command_handler('py.test', pytest)
+    )
+
+    # set the handler and the subparser for the logs command
+    log_sub_parser.set_defaults(
+        handler=lambda: invoke_command_handler('logs', logs, log_parser),
+    )
+    return parser.parse_args(sys.argv[1:2])
+
+
+def invoke_command_handler(command, func, arg_parser=None):
+    """This invokes the func, passing it appropriate arguments.
+
+    This finds all args after the first occurrence of `command` in sys.argv.
+    If given, `arg_parser` will parse the args. Then `func` is invoke with the
+    args (or parsed args).
+    """
+    i = sys.argv.index(command)
+    args = sys.argv[i+1:]
+    if arg_parser:
+        args = arg_parser.parse_args(args)
+    return func(args)
+
+
+def main():
+    args = parse_args()
+    sys.exit(args.handler())
+
+
+if __name__ == '__main__':
+    main()

--- a/ruiner/test/base.py
+++ b/ruiner/test/base.py
@@ -14,23 +14,22 @@ from ruiner.common import waiters
 from ruiner.common.config import cfg
 from ruiner.common.ini import IniFile
 
-LOG = utils.create_logger(__name__)
-
 
 class DockerComposeYamlTemplate(object):
     """A tool to generate a designate.yml for docker-compose"""
 
-    def __init__(self, tag=None):
+    def __init__(self, logger, tag=None):
+        self.log = logger
         self.source_template = './ruiner/templates/designate.yml.jinja2'
         self.output_file = utils.new_temp_file(self._filetag(tag), ".yml")
-        LOG.debug("using designate.yml generated at %s", self.output_file)
+        self.log.debug("using designate.yml generated at %s", self.output_file)
 
     def render(self, **kwargs):
         templ = jinja2.Template(open(self.source_template).read())
         content = templ.render(**kwargs)
         with open(self.output_file, 'w') as f:
             f.write(content)
-        LOG.debug("%s has content:\n%s", self.output_file, content)
+        self.log.debug("%s has content:\n%s", self.output_file, content)
 
     def _filetag(self, tag):
         if tag:
@@ -45,14 +44,24 @@ class BaseTest(unittest.TestCase):
         super(BaseTest, cls).setUpClass()
         cls.interval = cfg.CONF.ruiner.interval
         cls.timeout = cfg.CONF.ruiner.timeout
+        cls.log_dir = utils.setup_log_dir()
 
     def setUp(self):
-        LOG.info("======== base class setup ========")
         super(BaseTest, self).setUp()
+        per_test_log_file = "{}.log".format(self.id())
+        self.log = utils.create_logger(self.id(), per_test_log_file)
+        self.log.info("======== base setup ========")
 
+
+class BaseDesignateTest(BaseTest):
+    """This class deploys Designate into docker containers on test setup"""
+
+    def setUp(self):
+        super(BaseDesignateTest, self).setUp()
+        self.log.info("======== base designate test setup ========")
+
+        # a unique tag to ensure unique, per-test filenames
         self.random_tag = utils.random_tag()
-
-        self.setup_log_dir()
 
         self.carina_dir = docker.discover_designate_carina_dir()
         self.project_name = utils.random_project_name(tag=self.random_tag)
@@ -66,6 +75,7 @@ class BaseTest(unittest.TestCase):
         self.show_designate_conf()
 
         self.docker_composer = docker.DockerComposer(
+            logger=self.log,
             compose_files=[
                 "base.yml", self.designate_yaml, "envs/slappy-bind/bind.yml",
             ],
@@ -77,35 +87,35 @@ class BaseTest(unittest.TestCase):
         self.services = self.discover_services()
         self.prechecks()
 
-        LOG.info("======== test start ========")
+        self.log.info("======== test start ========")
 
     def tearDown(self):
-        LOG.info("======== base class teardown ========")
+        self.log.info("======== base designate test teardown ========")
         self.show_docker_logs()
         self.cleanup_environment()
         self.summarize()
         super(BaseTest, self).tearDown()
 
     def summarize(self):
-        LOG.info("======== SUMMARY ========")
+        self.log.info("======== SUMMARY ========")
         tag = getattr(self, 'random_tag', 'N/A')
         log_dir = getattr(self, 'log_dir', 'N/A')
         services_logfile = getattr(self, 'docker_logs_file', 'N/A')
         designate_git_url = cfg.CONF.ruiner.designate_git_url
         designate_version = cfg.CONF.ruiner.designate_version
 
-        LOG.info("tag . . . . . . . . . . : %s", tag)
-        LOG.info("log_dir . . . . . . . . : %s", log_dir)
-        LOG.info("service log . . . . . . : %s", services_logfile)
-        LOG.info("designate_git_url . . . : %s", designate_git_url)
-        LOG.info("designate_version . . . : %s", designate_version)
+        self.log.info("tag . . . . . . . . . . : %s", tag)
+        self.log.info("log_dir . . . . . . . . : %s", log_dir)
+        self.log.info("service log . . . . . . : %s", services_logfile)
+        self.log.info("designate_git_url . . . : %s", designate_git_url)
+        self.log.info("designate_version . . . : %s", designate_version)
 
     def configure_designate_conf(self):
         """This method may be overridden by subclasses. You MUST do all
         customization of self.designate_conf in this method, so that the file
         is prepared before the images are built.
         """
-        LOG.info("======== configuring designate.conf ========")
+        self.log.info("======== configuring designate.conf ========")
         conf = IniFile(self.designate_conf)
         conf.set("DEFAULT", "debug", True)
         conf.set("service:worker", "poll_timeout", 2)
@@ -114,11 +124,6 @@ class BaseTest(unittest.TestCase):
         conf.set("service:worker", "poll_delay", 2)
 
         conf.set("producer_task:worker_periodic_recovery", "interval", 30)
-
-    def setup_log_dir(self):
-        base_dir = os.path.realpath(cfg.CONF.ruiner.log_dir.rstrip('/'))
-        self.log_dir = os.path.join(base_dir, self.random_tag)
-        utils.mkdirs(self.log_dir)
 
     def init_tmp_dir(self):
         """There are some docker env config files we'll create dynamically.
@@ -140,7 +145,8 @@ class BaseTest(unittest.TestCase):
         filetag = "designate-%s-" % self.random_tag
         self.designate_conf = utils.new_temp_file(filetag, ".conf")
         self.addCleanup(utils.cleanup_file, self.designate_conf)
-        LOG.debug("using designate.conf generated at %s", self.designate_conf)
+        self.log.debug("using designate.conf generated at %s",
+                       self.designate_conf)
 
         # initialize designate.conf to some defaults
         src_path = os.path.join(
@@ -149,14 +155,14 @@ class BaseTest(unittest.TestCase):
         shutil.copyfile(src_path, self.designate_conf)
 
     def show_designate_conf(self):
-        LOG.debug("designate.conf is at %r:\n%s", self.designate_conf,
-                  open(self.designate_conf, 'r').read())
+        self.log.debug("designate.conf is at %r:\n%s", self.designate_conf,
+                       open(self.designate_conf, 'r').read())
 
     def init_docker_compose_yaml(self):
         # the docker compose yaml does not work with absolute paths
         designate_conf = os.path.relpath(self.designate_conf, self.carina_dir)
 
-        templ = DockerComposeYamlTemplate(tag=self.random_tag)
+        templ = DockerComposeYamlTemplate(self.log, tag=self.random_tag)
         templ.render(
             DESIGNATE_GIT_URL=cfg.CONF.ruiner.designate_git_url,
             DESIGNATE_VERSION=cfg.CONF.ruiner.designate_version,
@@ -170,7 +176,7 @@ class BaseTest(unittest.TestCase):
     def discover_services(self):
         """Discover docker service locations (url, host:port) and return a dict
         mapping the docker service name to the location"""
-        LOG.info("======== discover service locations ========")
+        self.log.info("======== discover service locations ========")
         services = {
             'api': self.discover_api(),
             'bind-1': self.discover_nameserver('bind-1'),
@@ -181,59 +187,64 @@ class BaseTest(unittest.TestCase):
 
     def discover_api(self, service_name='api', port=9001):
         url = "http://%s" % self.docker_composer.get_host(service_name, port)
-        LOG.info("%s:%s -> %s", service_name, port, url)
+        self.log.info("%s:%s -> %s", service_name, port, url)
         return url
 
     def discover_nameserver(self, service_name, port=53, protocol='udp'):
         location = self.docker_composer.get_host(service_name, port, protocol)
-        LOG.info("%s:%s/%s -> %s", service_name, port, protocol, location)
+        self.log.info("%s:%s/%s -> %s", service_name, port, protocol, location)
         return location
 
     def deploy_environment(self):
-        LOG.info("======== deploying env (%s) ========", self.project_name)
+        self.log.info("======== deploying env (%s) ========",
+                      self.project_name)
         out, _, ret = self.docker_composer.build()
-        LOG.debug("stdout:\n%s", out)
+        self.log.debug("stdout:\n%s", out)
         self.assertEqual(ret, 0)
 
         out, _, ret = self.docker_composer.up()
-        LOG.debug("stdout:\n%s", out)
+        self.log.debug("stdout:\n%s", out)
         self.assertEqual(ret, 0)
 
         sleep_time = cfg.CONF.ruiner.service_startup_wait_time
-        LOG.info("waiting %s seconds for services to start up", sleep_time)
+        self.log.info("waiting %s seconds for services to start up",
+                      sleep_time)
         time.sleep(sleep_time)
 
     def cleanup_environment(self):
-        LOG.info("======== cleaning up env (%s) ========", self.project_name)
+        self.log.info("======== cleaning up env (%s) ========",
+                      self.project_name)
         _, _, ret = self.docker_composer.down()
         if ret != 0:
-            LOG.error("FAILED TO CLEANUP ENV (project=%s)", self.project_name)
-            LOG.error("TRY `docker-compose -p %s down`", self.project_name)
+            self.log.error("FAILED TO CLEANUP ENV (project=%s)",
+                           self.project_name)
+            self.log.error("try `docker-compose -p %s down`",
+                           self.project_name)
         self.assertEqual(
             ret, 0, "FAILED TO CLEANUP ENV (project=%s)" % self.project_name
         )
 
     def prechecks(self):
         """Do quick checks of the api + nameservers"""
-        LOG.info("======== checking environment preconditions ========")
-        LOG.info("checking the api by listing zones")
+        self.log.info("======== checking environment preconditions ========")
+        self.log.info("checking the api by listing zones")
         resp = self.api.list_zones()
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         assert resp.ok
 
         # these queries raise exceptions on timeouts
         for service_name in ('bind-1', 'bind-2'):
-            LOG.info("checking %s by digging it", service_name)
+            self.log.info("checking %s by digging it", service_name)
             resp = utils.dig("poo.com.", self.services[service_name], "ANY")
-            LOG.debug("\n%s", resp)
+            self.log.debug("\n%s", resp)
 
-        LOG.info("all prechecks have passed!")
+        self.log.info("all prechecks have passed!")
 
     def kill_nameserver(self, service_name='bind-2'):
         """Stop a nameserver, causing new operations to go to error"""
         self.docker_composer.kill(service_name)
         if not self.nameserver_is_down(service_name):
-            LOG.debug("failed to kill container %s", service_name)
+            self.log.debug("failed to kill container %s", service_name)
 
     def restart_nameserver(self, service_name='bind-2'):
         utils.require_success(self.docker_composer.start(service_name))
@@ -243,19 +254,19 @@ class BaseTest(unittest.TestCase):
         self.services[service_name] = location
 
         sleep_time = cfg.CONF.ruiner.service_startup_wait_time
-        LOG.info("waiting %s seconds for %s to start up", sleep_time,
-                 service_name)
+        self.log.info("waiting %s seconds for %s to start up", sleep_time,
+                      service_name)
         time.sleep(sleep_time)
 
     def nameserver_is_down(self, service_name='bind-2'):
         """Return True if the nameserver does not respond to queries"""
-        LOG.debug("checking %s is down", service_name)
+        self.log.debug("checking %s is down", service_name)
         host = self.services[service_name]
         try:
             utils.dig("poo.com.", host, "ANY")
         except dns.exception.Timeout:
-            LOG.debug("verified %s is down (query to %s timed out)",
-                      service_name, host)
+            self.log.debug("verified %s is down (query to %s timed out)",
+                           service_name, host)
             return True
         return False
 
@@ -265,47 +276,48 @@ class BaseTest(unittest.TestCase):
         self.docker_logs_file = os.path.realpath(
             os.path.join(self.log_dir, 'docker-services.log'),
         )
-        LOG.info("writing docker service logs to: %s", self.docker_logs_file)
+        self.log.info("writing docker service logs to: %s",
+                      self.docker_logs_file)
         with open(self.docker_logs_file, 'w') as f:
             f.write("stdout:\n%s" % utils.strip_ansi(out))
             f.write("stderr:\n%s" % utils.strip_ansi(err))
 
         if ret != 0:
-            LOG.error("failed to get docker logs!")
-            LOG.error("stderr: %s", err)
+            self.log.error("failed to get docker logs!")
+            self.log.error("stderr: %s", err)
 
     def get_zone(self, name, zid):
         """Fetch the zone. Return the response. self.fail() on status >= 500"""
-        LOG.info("fetching zone %s (id=%s)", name, zid)
+        self.log.info("fetching zone %s (id=%s)", name, zid)
         resp = self.api.get_zone(zid)
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         if resp.status_code >= 500:
             self.fail("failed to fetch zone (status=%s)" % resp.status_code)
         return resp
 
     def create_zone(self):
         """Create a zone. Return (name, zone_id) on success, or self.fail()"""
-        LOG.info("creating a zone")
+        self.log.info("creating a zone")
         resp = self.api.create_zone()
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         if resp.status_code != 202:
             self.fail("failed to create zone (status=%s)" % resp.status_code)
         return resp.json()["name"], resp.json()["id"]
 
     def delete_zone(self, name, zid):
         """Delete a zone. Calls self.fail() if the delete fails"""
-        LOG.info("deleting zone %s", name)
+        self.log.info("deleting zone %s", name)
         resp = self.api.delete_zone(zid)
         if not resp.ok:
             self.fail("failed to delete zone %s", name)
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
 
     def create_recordset(self, zname, zid):
         """Create a recordset. Return (rrname, rrid) on success, or else
         self.fail()"""
-        LOG.info("creating a recordset")
+        self.log.info("creating a recordset")
         resp = self.api.create_recordset(zname, zid)
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         if resp.status_code != 202:
             self.fail("failed to create recordset (status=%s)"
                       % resp.status_code)
@@ -315,18 +327,19 @@ class BaseTest(unittest.TestCase):
         """Wait for the given zone to go to ERROR. Fail the test if we fail to
         timeout before seeing an ERROR status.
         """
-        LOG.info("waiting for zone %s to go to ERROR...", name)
+        self.log.info("waiting for zone %s to go to ERROR...", name)
         resp = waiters.wait_for_status(
             lambda: self.api.get_zone(zid), ["ERROR", "ACTIVE"], self.interval,
             self.timeout,
         )
 
         if resp.ok and resp.json()['status'] == 'ERROR':
-            LOG.info("...done waiting for zone %s (status = ERROR)", name)
+            self.log.info("...done waiting for zone %s (status = ERROR)", name)
         else:
-            LOG.error("...done waiting for zone %s (status != ERROR)", name)
+            self.log.error("...done waiting for zone %s (status != ERROR)",
+                           name)
 
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         self.assertEqual(
             resp.json().get("status"), "ERROR",
             "zone %s failed to go to ERROR (timeout=%s)" % (name, self.timeout)
@@ -336,18 +349,20 @@ class BaseTest(unittest.TestCase):
         """Wait for the given zone to go to ACTIVE. Fail the test if we timeout
         before seeing an ACTIVE status.
         """
-        LOG.info("waiting for zone %s to go to ACTIVE...", name)
+        self.log.info("waiting for zone %s to go to ACTIVE...", name)
         resp = waiters.wait_for_status(
             lambda: self.api.get_zone(zid), ["ACTIVE"], self.interval,
             self.timeout
         )
 
         if resp.ok and resp.json()['status'] == 'ACTIVE':
-            LOG.info("...done waiting for zone %s (status = ACTIVE)", name)
+            self.log.info("...done waiting for zone %s (status = ACTIVE)",
+                          name)
         else:
-            LOG.error("...done waiting for zone %s (status != ACTIVE)", name)
+            self.log.error("...done waiting for zone %s (status != ACTIVE)",
+                           name)
 
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         self.assertEqual(
             resp.json().get("status"), "ACTIVE",
             "zone %s failed to go ACTIVE (timeout=%s)" % (name, self.timeout)
@@ -357,17 +372,17 @@ class BaseTest(unittest.TestCase):
         """Wait for the given zone to return a 404. Fail the test if we timeout
         before seeing a 404 status code.
         """
-        LOG.info("waiting for zone %s to 404...", name)
+        self.log.info("waiting for zone %s to 404...", name)
         resp = waiters.wait_for_404(
             lambda: self.api.get_zone(zid), self.interval, self.timeout,
         )
 
         if resp.status_code == 404:
-            LOG.info("...done waiting for zone %s (status = 404)", name)
+            self.log.info("...done waiting for zone %s (status = 404)", name)
         else:
-            LOG.error("...done waiting for zone %s (status != 404)", name)
+            self.log.error("...done waiting for zone %s (status != 404)", name)
 
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         self.assertEqual(
             resp.status_code, 404,
             "zone %s failed to 404 (timeout=%s)" % (name, self.timeout)
@@ -375,8 +390,8 @@ class BaseTest(unittest.TestCase):
 
     def wait_for_name_on_nameserver(self, name, service_name):
         """Wait for a successful, non-empty response from the nameserver"""
-        LOG.info("waiting for %s to go live on nameserver %s...", name,
-                 service_name)
+        self.log.info("waiting for %s to go live on nameserver %s...", name,
+                      service_name)
 
         host = self.services[service_name]
         resp = waiters.wait_for_name_on_nameserver(
@@ -384,12 +399,14 @@ class BaseTest(unittest.TestCase):
         )
 
         if bool(resp.answer):
-            LOG.info("...done waiting for %s on nameserver %s (found)", name,
-                     service_name)
+            self.log.info("...done waiting for %s on nameserver %s (found)",
+                          name, service_name)
         else:
-            LOG.error("...done waiting for %s on nameserver %s (not found)",
-                      name, service_name)
-        LOG.debug("%s\n", resp)
+            self.log.error(
+                "...done waiting for %s on nameserver %s (not found)",
+                name, service_name,
+            )
+        self.log.debug("\n%s", resp)
 
         self.assertTrue(
             bool(resp.answer),
@@ -399,8 +416,8 @@ class BaseTest(unittest.TestCase):
         )
 
     def wait_for_name_removed_from_nameserver(self, name, service_name):
-        LOG.info("waiting for %s to be removed from nameserver %s", name,
-                 service_name)
+        self.log.info("waiting for %s to be removed from nameserver %s", name,
+                      service_name)
 
         host = self.services[service_name]
         resp = waiters.wait_for_name_removed_from_nameserver(
@@ -408,13 +425,17 @@ class BaseTest(unittest.TestCase):
         )
 
         if not bool(resp.answer):
-            LOG.info("...done waiting for %s to be removed from nameserver %s",
-                     name, service_name)
+            self.log.info(
+                "...done waiting for %s to be removed from nameserver %s",
+                name, service_name,
+            )
         else:
-            LOG.error("...done waiting for %s to be removed from nameserver %s"
-                      " (not removed)", name, service_name)
+            self.log.error(
+                "...done waiting for %s to be removed from nameserver %s"
+                " (not removed)", name, service_name,
+            )
 
-        LOG.debug("%s\n", resp)
+        self.log.debug("\n%s", resp)
         self.assertFalse(
             bool(resp.answer),
             "zone %s never removed from nameserver %s (timeout=%s)" % (

--- a/ruiner/test/test_docker_composer.py
+++ b/ruiner/test/test_docker_composer.py
@@ -1,14 +1,16 @@
 import mock
 import os
-import unittest
 
 from ruiner.common.docker import DockerComposer
+from ruiner.test import base
 
 
-class TestDockerComposer(unittest.TestCase):
+class TestDockerComposer(base.BaseTest):
 
     def setUp(self):
+        super(TestDockerComposer, self).setUp()
         self.dc = DockerComposer(
+            logger=self.log,
             project_name='wumbo',
             compose_files=['hello.yml', 'goodbye.yml'],
             carina_dir='./fake-designate-carina',

--- a/ruiner/test/test_ini.py
+++ b/ruiner/test/test_ini.py
@@ -1,18 +1,19 @@
 import tempfile
-import unittest
 import logging
 
 from ruiner.common.ini import IniFile
+from ruiner.test import base
 
 LOG = logging.getLogger(__name__)
 
 
-class TestIniFile(unittest.TestCase):
+class TestIniFile(base.BaseTest):
 
     def setUp(self):
+        super(TestIniFile, self).setUp()
         self.tempfile = tempfile.NamedTemporaryFile()
         self.filename = self.tempfile.name
-        LOG.info("using tempfile %s", self.filename)
+        self.log.info("using tempfile %s", self.filename)
         self.inifile = IniFile(self.filename)
 
     def assertFileContains(self, expected):

--- a/ruiner/test/test_log_colors.py
+++ b/ruiner/test/test_log_colors.py
@@ -1,8 +1,8 @@
-import unittest
 from ruiner.common import utils
+from ruiner.test import base
 
 
-class TestLogColor(unittest.TestCase):
+class TestLogColor(base.BaseTest):
 
     def test_log_color(self):
         # this "test" doesn't check anything, but is useful for checking

--- a/ruiner/test/test_nameserver_recovery.py
+++ b/ruiner/test/test_nameserver_recovery.py
@@ -1,11 +1,8 @@
-from ruiner.common import utils
 from ruiner.common.ini import IniFile
 from ruiner.test import base
 
-LOG = utils.create_logger(__name__)
 
-
-class TestNameserverRecovery(base.BaseTest):
+class TestNameserverRecovery(base.BaseDesignateTest):
 
     def test_create_zone_while_nameserver_is_down(self):
         """Create a zone while a nameserver is down. Check the zone goes to
@@ -42,7 +39,7 @@ class TestNameserverRecovery(base.BaseTest):
         self.wait_for_zone_to_active(zname, zid)
 
 
-class TestThresholdPercentage(base.BaseTest):
+class TestThresholdPercentage(base.BaseDesignateTest):
 
     def configure_designate_conf(self):
         super(TestThresholdPercentage, self).configure_designate_conf()
@@ -74,7 +71,7 @@ class TestThresholdPercentage(base.BaseTest):
         self.wait_for_name_on_nameserver(name, 'bind-2')
 
         # check the zone is still active
-        LOG.info("checking the zone is (still) active")
+        self.log.info("checking the zone is (still) active")
         resp = self.get_zone(name, zid)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['status'], 'ACTIVE')

--- a/ruiner/test/test_quota.py
+++ b/ruiner/test/test_quota.py
@@ -5,7 +5,7 @@ from ruiner.common.ini import IniFile
 LOG = utils.create_logger(__name__)
 
 
-class TestZonePerTenantQuota(base.BaseTest):
+class TestZonePerTenantQuota(base.BaseDesignateTest):
 
     def configure_designate_conf(self):
         super(TestZonePerTenantQuota, self).configure_designate_conf()
@@ -25,7 +25,7 @@ class TestZonePerTenantQuota(base.BaseTest):
 
         # create an additional zone. check that it 413s.
         resp = self.api.create_zone()
-        LOG.debug(utils.resp_to_string(resp))
+        self.log.debug(utils.resp_to_string(resp))
         self.assertEqual(resp.status_code, 413)
         self.assertEqual(resp.json()["code"], 413)
         self.assertEqual(resp.json()["type"], "over_quota")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import setuptools
+
+setup_params = dict(
+    name='designate-ruiner',
+    version='0.0.1',
+    entry_points={
+        'console_scripts': [
+            'ruiner=ruiner.common.runner:main',
+        ],
+    },
+)
+
+if __name__ == '__main__':
+    setuptools.setup(**setup_params)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ colorlog==2.6.1
 dnspython==1.12.0
 py==1.4.31
 pytest==2.9.1
+pytest-html==1.10.0
 pytest-xdist==1.14
 requests==2.9.1
 oslo.config==3.9.0

--- a/tools/wrath/index.html.j2
+++ b/tools/wrath/index.html.j2
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title }}</title>
+</head>
+
+<body>
+{% for dir in dirs | sort %}
+<p><code>{{ loop.index }}. {{ dir }}</code>
+    {% for item in dirs[dir] %}
+        {% if item.has_html %}
+          <br>
+          <a target="_blank" href="/{{ item.path }}.html"><code>{{ item.name }}</code></a>
+          <a target="_blank" href="/{{ item.path }}"><code>[raw]</code></a>
+        {% else %}
+          <br>
+          <a target="_blank" href="/{{ item.path }}"><code>{{ item.name }}</code></a>
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+</body>
+</html>

--- a/tools/wrath/log.html.j2
+++ b/tools/wrath/log.html.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.INFO { color: green; }
+.ERROR, .CRITICAL { color: red; }
+.WARNING { color: orange; }
+</style>
+</head>
+
+<body>
+
+<pre>{% for item in lines %}
+<code class="{{ item.loglevel }}">{{ "%4d |" % loop.index }} {{ item.line.strip() }}</code>{% endfor %}
+</pre>
+
+</body>
+</html>

--- a/tools/wrath/wrath.py
+++ b/tools/wrath/wrath.py
@@ -1,0 +1,277 @@
+import argparse
+import os
+import sys
+
+import jinja2
+
+from ruiner.common.utils import strip_ansi
+
+
+class Trie(object):
+    """A prefix trie for paths:
+
+        >>> trie.insert('ruiner-logs/1234/things')
+        >>> trie.insert('ruiner-logs/1234/stuff')
+        >>> trie.insert('ruiner-logs/5678/things')
+
+    Each part of a path becomes a node:
+
+        'ruiner-logs'--> '1234'--> 'things'
+                    \         \--> 'stuff'
+                     --> '5678'
+
+    This lets us list prefixes up to a particular depth:
+
+        >>> trie.prefixes(1)
+        'ruiner-logs'
+        >>> trie.prefixes(2)
+        ['ruiner-logs/1234', 'ruiner-logs/5678']
+
+    We can list everything:
+
+        >>> trie.traverse()
+        ['./ruiner-logs/1234/things', './ruiner-logs/1234/stuff',
+         './ruiner-logs/5678/things']
+
+    We can find a sub-tree and perform the same operations:
+
+        >>> x = trie.find('ruiner-logs/1234')
+        >>> x.prefixes(1)
+        ['things', 'stuff']
+    """
+
+    def __init__(self, val=''):
+        self.val = val
+        self.children = {}
+
+    def __str__(self):
+        return 'Trie(%s)' % self.val
+
+    def __repr__(self):
+        return str(self)
+
+    def traverse(self):
+        """Return a list containing all (unique) inserted items"""
+        if not self.children:
+            return [self.val]
+        result = []
+        for child in self.children.values():
+            for item in child.traverse():
+                if self.val:
+                    item = self.val + '/' + item
+                result.append(item)
+        return result
+
+    def prefixes(self, depth, prefix=''):
+        """Return all prefixes up to the given depth"""
+        prefix += self.val if not prefix else "/" + self.val
+        result = []
+        if depth <= 0 or not self.children:
+            result.append(prefix)
+        else:
+            for child in self.children.values():
+                for pre in child.prefixes(depth - 1, prefix):
+                    result.append(pre)
+        return result
+
+    def insert(self, path):
+        parts = path.lstrip('.').split('/')
+        current = self
+        for c in parts:
+            if c in current.children:
+                new = current.children[c]
+            else:
+                new = Trie(c)
+                current.children[c] = new
+            current = new
+
+    def find(self, prefix):
+        """Return the sub-trie at the prefix"""
+        parts = prefix.split('/')
+        current = self
+        for c in parts:
+            if c not in current.children:
+                return None
+            current = current.children[c]
+        return current
+
+    @classmethod
+    def test(cls):
+        paths = [
+            'abc/thing.log',
+            'abc/123/thing.log',
+            'abc/123/stuff.txt',
+            'abc/456/thing.log',
+            'abc/456/stuff.txt',
+            'def/123/thing.log',
+            'def/123/stuff.txt',
+            'def/456/thing.log',
+            'def/456/stuff.txt',
+        ]
+        trie = cls()
+        for p in paths:
+            trie.insert(p)
+        assert sorted(trie.traverse()) == sorted(paths)
+
+        assert sorted(trie.prefixes(1)) == ['abc', 'def']
+        assert sorted(trie.prefixes(2)) == sorted([
+            'abc/thing.log', 'abc/123', 'abc/456', 'def/123', 'def/456'
+        ])
+        assert sorted(trie.prefixes(3)) == sorted(paths)
+        assert sorted(trie.prefixes(4)) == sorted(paths)
+
+        sub = trie.find('abc')
+        assert sub.val == 'abc'
+        assert sorted(sub.prefixes(1)) == sorted([
+            'abc/thing.log', 'abc/123', 'abc/456'
+        ])
+        assert sorted(sub.prefixes(2)) == sorted([
+            'abc/thing.log',
+            'abc/123/thing.log',
+            'abc/123/stuff.txt',
+            'abc/456/thing.log',
+            'abc/456/stuff.txt',
+        ])
+
+        sub = trie.find('abc/123')
+        assert sub.val == '123'
+        assert sorted(sub.prefixes(1)) == sorted([
+            '123/thing.log', '123/stuff.txt',
+        ])
+
+
+def read_filenames():
+    return [line.strip().lstrip('./') for line in sys.stdin]
+
+
+def find_jinja_source(filename):
+    """Look for the file in the current dir or this module's containing dir.
+
+    Raise an exception if none of the locations have the file.
+    """
+    module_dir = os.path.dirname(__file__)
+    locations = [filename, os.path.join(module_dir, filename)]
+    for loc in locations:
+        if os.path.exists(loc):
+            return loc
+    raise Exception("Failed to find %s at any of %s" % (filename, locations))
+
+
+def detect_log_level(line):
+    for level in ('INFO', 'DEBUG', 'WARNING', 'CRITICAL', 'ERROR'):
+        if level in line:
+            return level
+    return 'UNKNOWN'
+
+
+def generate_index_html(template_file='index.html.j2'):
+    """Return a string containing html for all paths in the trie.
+
+    For all <name>.log files, if a <name>.log.html file is in the trie, then
+    we link to the html version of the file instead of the file itself. In this
+    case, a second link to the raw html is added.
+    """
+    filelist = read_filenames()
+    trie = Trie()
+    for f in filelist:
+        trie.insert(f)
+
+    template_file = find_jinja_source(template_file)
+    template = jinja2.Template(open(template_file).read())
+
+    dirs = {}
+    for d in trie.prefixes(2):
+        node = trie.find(d)
+        for child in node.children.values():
+            children = []
+            for p in child.traverse():
+                fullpath = d + '/' + p
+                if not fullpath.endswith('log.html'):
+                    n = trie.find(fullpath)
+                    children.append({
+                        'name': n.val,
+                        'path': fullpath,
+                        'has_html': bool(trie.find(fullpath + ".html")),
+                    })
+            if children:
+                dirs[node.val + '/' + child.val] = children
+
+    kwargs = {
+        'title': 'Rackspace CloudDNS CI',
+        'dirs': dirs,
+
+    }
+    print template.render(**kwargs)
+    return 0
+
+
+def write_html_versions_of_logs(template_file='log.html.j2'):
+    filenames = read_filenames()
+
+    template_file = find_jinja_source(template_file)
+    template = jinja2.Template(open(template_file).read())
+    for source in (f for f in filenames if f.endswith('.log')):
+        dest = "%s.html" % source
+
+        with open(source, 'r') as f:
+            lines = [strip_ansi(line.strip()) for line in f]
+
+        lines = [
+            {
+                'line': line,
+                'loglevel': detect_log_level(line),
+            } for line in lines
+        ]
+
+        print 'Generating %s' % dest
+        content = template.render(lines=lines)
+        with open(dest, 'w') as f:
+            f.write(content)
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""Generate an html listing of ruiner log files. This is
+intended to be used in conjunction with the `ruiner` script:
+
+To generate an index.html, with links to other files:
+
+    $ ruiner logs --last -r | python wrath.py --index > index.html
+
+Write out html versions of all *.log files:
+
+    $ ruiner logs --last -r | python wrath.py --html_log
+
+""")
+
+    parser.add_argument(
+        '--test', action='store_true', help="Run internal tests")
+    parser.add_argument(
+        '--html-log', dest='html_log', action='store_true',
+        help="Write html versions of log files")
+    parser.add_argument(
+        '--index', dest='index', action='store_true',
+        help='Generate an index.html with a "directory listing"')
+
+    return parser, parser.parse_args()
+
+
+def main():
+    parser, args = parse_args()
+    if args.test:
+        Trie.test()
+    elif args.index:
+        return generate_index_html()
+    elif args.html_log:
+        return write_html_versions_of_logs()
+    else:
+        parser.print_help()
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ commands = py.test -n 4 -v ./ruiner/test
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 ./ruiner
+commands = flake8 ./ruiner ./tools/wrath


### PR DESCRIPTION
- [x] Add a wrapper script, to ensure logs go to the same timestamped dir (even with multiple processes)
- [x] Support listing logs from previous runs using the wrapper script
- [x] Create per test log dirs (named by test case)
- [x] Store the test case's logs, docker service logs, designate.conf, designate.yaml in the per test log dir